### PR TITLE
Add promptler to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     },
     "dependencies": {
         "@banjoanton/spa-runner": "0.0.19",
+        "promptler": "^0.0.4",
         "toastler": "^0.0.6"
     }
 }


### PR DESCRIPTION
Promptler was missing from package.json making a fresh clone of project to fail at build.